### PR TITLE
pr maintainer check: pass if maintainer opened

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,8 +14,42 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            if (!pr.assignees || pr.assignees.length === 0) {
-              core.setFailed('PR must have at least one assignee.');
+            const author = pr.user && pr.user.login ? pr.user.login : '';
+            // Load maintainers from optional .github/MAINTAINERS (usernames, one per line, optionally prefixed with @)
+            async function loadMaintainers() {
+              const set = new Set();
+              try {
+                const repo = await github.rest.repos.get({ owner: context.repo.owner, repo: context.repo.repo });
+                const defaultBranch = repo.data.default_branch;
+                const { data } = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: '.github/MAINTAINERS',
+                  ref: defaultBranch,
+                });
+                const content = Buffer.from(data.content, 'base64').toString('utf8');
+                for (const raw of content.split(/\r?\n/)) {
+                  const l = raw.trim();
+                  if (!l || l.startsWith('#')) continue;
+                  set.add(l.replace(/^@/, ''));
+                }
+              } catch (e) {
+                // Fallback: treat repo owner as maintainer if file is missing or unreadable
+                set.add(context.repo.owner);
+              }
+              if (set.size === 0) {
+                set.add(context.repo.owner);
+              }
+              return set;
+            }
+
+            const maintainers = await loadMaintainers();
+            const isMaintainerAuthor = maintainers.has(author);
+            const hasAssignee = pr.assignees && pr.assignees.length > 0;
+            if (!hasAssignee && isMaintainerAuthor) {
+              core.notice(`No assignee set, but PR author @${author} is a maintainer; passing assignment check.`);
+            } else if (!hasAssignee) {
+              core.setFailed('PR must have at least one assignee (or be opened by a maintainer).');
             }
       - name: Require linked issue (mention or closing keywords)
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

slight ci change so that if the pr is opened by the maintainer, it does not generate the err

## Linked Issue(s)

Closes #20 

## Checklist

- [ x ] I am assigned to the linked issue(s)
- [ ] I wrote tests or updated existing tests
- [ ] I ran `go build` and `go test ./...`
- [ ] I updated docs/README if needed