### PR TITLE
input step + i for input mode and then a confirmation for checkout -b

### DIFF
--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -383,3 +383,15 @@ func Checkout(repoRoot, branch string) error {
     }
     return nil
 }
+
+// CheckoutNew creates and switches to a new branch: `git checkout -b <name>`.
+func CheckoutNew(repoRoot, name string) error {
+    if strings.TrimSpace(name) == "" {
+        return errors.New("empty branch name")
+    }
+    cmd := exec.Command("git", "-C", repoRoot, "checkout", "-b", name)
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return fmt.Errorf("git checkout -b %s: %w: %s", name, err, string(out))
+    }
+    return nil
+}


### PR DESCRIPTION
## Summary

now `b` has a `n` option which will trigger the new branch input field -> `i` for input mode and enter branch name

## Linked Issue(s)

Closes #24 

## Checklist

- [ x ] I am assigned to the linked issue(s)
- [ ] I wrote tests or updated existing tests
- [ x ] I ran `go build` and `go test ./...`
- [ ] I updated docs/README if needed

