### PR TITLE
horizontal scroll for long lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Watcher TUI that shows changed files on the left and a side-by-side diff on the 
 
 - `j/k` or arrow keys: move selection
 - `J/K`, `PgDn/PgUp`: scroll diff
+- `{/}`: horizontal scroll in diff pane
 - `s`: toggle side-by-side vs inline
 - `u`: open uncommit wizard (remove selected files from last commit; shows all current changes for selection)
 - `R`: open reset/clean wizard (repo-wide): select reset `git reset --hard`, clean `git clean -d -f`, optionally include ignored; shows preview, then two confirmations (yellow + red)


### PR DESCRIPTION
## Summary

Implemented horizontal scroll with `{` and `}`

## Linked Issue(s)

Fixes #8

## Checklist

- [ x ] I am assigned to the linked issue(s)
- [ ] I wrote tests or updated existing tests
- [ x ] I ran `go build` and `go test ./...`
- [ x ] I updated docs/README if needed

