### PR TITLE
fix: Horizontal Scroll Causes Complete Overflow

### DIFF
--- a/internal/tui/program.go
+++ b/internal/tui/program.go
@@ -1,21 +1,21 @@
 package tui
 
 import (
-    "fmt"
-    "sort"
-    "strings"
+	"fmt"
+	"sort"
 	"strconv"
-    "time"
+	"strings"
+	"time"
 	"unicode/utf8"
 
-    "github.com/charmbracelet/bubbles/textinput"
-    "github.com/charmbracelet/bubbles/viewport"
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/charmbracelet/lipgloss"
-    "github.com/charmbracelet/x/ansi"
-    "github.com/interpretive-systems/diffium/internal/diffview"
-    "github.com/interpretive-systems/diffium/internal/gitx"
-    "github.com/interpretive-systems/diffium/internal/prefs"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/interpretive-systems/diffium/internal/diffview"
+	"github.com/interpretive-systems/diffium/internal/gitx"
+	"github.com/interpretive-systems/diffium/internal/prefs"
 )
 
 const (
@@ -1903,8 +1903,6 @@ func (m model) rightBodyLinesAll(width int) []string {
                     l := m.renderSideCell(r, "left", colsW)
                     rr := m.renderSideCell(r, "right", colsW)
                     if m.rightXOffset > 0 {
-                        l = sliceANSI(l, m.rightXOffset, colsW)
-                        rr = sliceANSI(rr, m.rightXOffset, colsW)
                         l = padExact(l, colsW)
                         rr = padExact(rr, colsW)
                     }
@@ -2606,13 +2604,10 @@ func (m model) renderSideCell(r diffview.Row, side string, width int) string {
         return ansi.Truncate(marker+" ", width, "")
     }
     bodyW := width - 2
-    // First clip right side to avoid wrapping
-    clipped := clipToWidth(content, bodyW)
-    // Then apply horizontal slice if any
-    if m.rightXOffset > 0 {
-        clipped = sliceANSI(clipped, m.rightXOffset, bodyW)
-    }
-    body := padExact(clipped, bodyW)
+
+    clipped := sliceANSI(content, m.rightXOffset, bodyW)
+    body := padExact(clipped, bodyW - m.rightXOffset)
+    
     return marker + " " + body
 }
 
@@ -2672,13 +2667,7 @@ func sliceANSI(s string, start, w int) string {
     }
     // First keep only the left portion up to start+w, then drop the first `start` columns.
     head := ansi.Truncate(s, start+w, "")
-    return ansi.TruncateLeft(head, w, "")
-}
-
-// clipToWidth trims the string to at most w cells without ellipsis.
-func clipToWidth(s string, w int) string {
-    if w <= 0 { return "" }
-    return ansi.Truncate(s, w, "")
+    return ansi.TruncateLeft(head, start, "")
 }
 
 // padExact pads s with spaces to exactly width w (ANSI-aware width).

--- a/internal/tui/program.go
+++ b/internal/tui/program.go
@@ -1902,10 +1902,8 @@ func (m model) rightBodyLinesAll(width int) []string {
                 } else {
                     l := m.renderSideCell(r, "left", colsW)
                     rr := m.renderSideCell(r, "right", colsW)
-                    if m.rightXOffset > 0 {
-                        l = padExact(l, colsW)
-                        rr = padExact(rr, colsW)
-                    }
+                    l = padExact(l, colsW)
+                    rr = padExact(rr, colsW)
                     lines = append(lines, l+mid+rr)
                 }
             }
@@ -2606,9 +2604,8 @@ func (m model) renderSideCell(r diffview.Row, side string, width int) string {
     bodyW := width - 2
 
     clipped := sliceANSI(content, m.rightXOffset, bodyW)
-    body := padExact(clipped, bodyW - m.rightXOffset)
     
-    return marker + " " + body
+    return marker + " " + clipped
 }
 
 // renderSideCellWrap renders a cell like renderSideCell but wraps the content


### PR DESCRIPTION
Summary
---

Made some changes in the rendering functions to fix the scroll overflow issue.

- Misplaced variable in the `sliceANSI` function causing complete removal of content string.
- `renderSideCell` cleaned to only have the slice to only have the slicing be done once directly using the content.
- `rightBodyLinesAll` cleaned to have the padding applied regardless of rightXOffset.


Previously:

https://github.com/user-attachments/assets/201d154e-1731-4574-be5e-4de8743b87b3

Fix:

https://github.com/user-attachments/assets/4501be83-ddf6-42c4-aa2e-9325c78e4ba4

Linked Issues
---
Fixes: #8 

Checklist
--

- [ ]  I am assigned to the linked issue(s)
- [ ]  I wrote tests or updated existing tests
- [x]  I ran `go build` and `go test ./...`
- [ ]  I updated docs/README if needed


