### PR TITLE
feat: ensure formatting runs during workflow checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Format
+        run: go fmt ./...
+
       - name: Build
         run: go build ./...
 


### PR DESCRIPTION
## Summary

Add a formatting step to the CI workflow to automatically format Go code during checks, ensuring consistent formatting and avoiding large diffs from formatting changes.

## Linked Issue(s)

Closes #64.

## Checklist

- [ ] I am assigned to the linked issue(s)
- [ ] ~~I wrote tests or updated existing tests~~ `CI workflow change only`
- [ ] ~~I ran `go build` and `go test ./...`~~ `CI workflow change only`
- [ ] ~~I updated docs/README if needed~~ `CI workflow change only`

